### PR TITLE
DaToggleButton styling fixes

### DIFF
--- a/gallery/src/components/SpacingExample.tsx
+++ b/gallery/src/components/SpacingExample.tsx
@@ -58,7 +58,7 @@ export const SpacingExample = () => {
 							<ArrowDropDown />
 						</DaToggleButton>
 					</DaToggleButtonGroup>
-					<Popper anchorEl={popperRef.current} open={isOpen}>
+					<Popper anchorEl={popperRef.current} open={isOpen} sx={{ backgroundColor: "white" }}>
 						<DaToggleButtonGroup
 							orientation="vertical"
 							value={groupValue}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalarkivet/mui-theme",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "MUI themes for Digitalarkivet applications",
 	"private": false,
 	"main": "dist/main.js",

--- a/src/DaToggleButton.ts
+++ b/src/DaToggleButton.ts
@@ -3,5 +3,4 @@ import { styled, ToggleButton } from "@mui/material"
 export const DaToggleButton = styled(ToggleButton)({
 	flex: "1 1 auto",
 	padding: "4px",
-	textTransform: "none",
 })

--- a/src/DaToggleButtonGroup.ts
+++ b/src/DaToggleButtonGroup.ts
@@ -19,7 +19,6 @@ export const DaToggleButtonGroup = styled(ToggleButtonGroup, {
 		},
 		"& .MuiToggleButton-root": {
 			color: colorBase.main,
-			backgroundColor: theme.palette.background.white,
 			marginLeft: "1px",
 
 			"&:first-of-type": {


### PR DESCRIPTION
By default, DaToggleButton should use all caps and be transparent.

The original implementation was a mix of two different designs,
this one follows the Design System.
