### PR TITLE
Use path imports for MUI components, to aid tree shaking

### DIFF
--- a/src/DaToggleButton.ts
+++ b/src/DaToggleButton.ts
@@ -1,4 +1,5 @@
-import { styled, ToggleButton } from "@mui/material"
+import { styled } from "@mui/material/styles"
+import ToggleButton from "@mui/material/ToggleButton"
 
 export const DaToggleButton = styled(ToggleButton)({
 	flex: "1 1 auto",

--- a/src/DaToggleButtonGroup.ts
+++ b/src/DaToggleButtonGroup.ts
@@ -1,4 +1,5 @@
-import { PaletteOptions, styled, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material"
+import ToggleButtonGroup, { ToggleButtonGroupProps } from "@mui/material/ToggleButtonGroup"
+import { PaletteOptions, styled } from "@mui/material/styles"
 
 type DaToggleButtonGroupProps = ToggleButtonGroupProps & {
 	palette?: keyof Pick<PaletteOptions, "primary" | "secondary" | "info" | "error" | "warning" | "success">

--- a/src/light.ts
+++ b/src/light.ts
@@ -202,13 +202,10 @@ const theme = createTheme(
 	themeColors,
 )
 
-
-
 declare module "@mui/material/Paper" {
 	interface PaperPropsVariantOverrides {
 		padded: true
 	}
 }
-
 
 export default theme


### PR DESCRIPTION
Option one in https://mui.com/material-ui/guides/minimizing-bundle-size/
