### PR TITLE
Add tailwind theme file

### DIFF
--- a/tailwind.css
+++ b/tailwind.css
@@ -3,6 +3,9 @@
 
 	--typography-font-size: 14px;
 	--typography-font-family: "'Suisse Intl', 'Suisse Intl Mono', 'Suisse Neue', Arial, sans-serif";
+	--typography-font-familiy-suisse-intl: "'Suisse Intl', Arial";
+	--typography-font-familiy-suisse-neue: "'Suisse Neue', 'Times New Roman'";
+	--typography-font-familiy-suisse-intl-mono: "'Suisse Intl Mono', Arial";
 	--typography-font-weight-bold: 500;
 	--typography-font-weight-roman: 400;
 	--typography-line-height-100: 1.0;

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,7 +1,7 @@
 @theme {
 	/*
 	 * -----------------------------------------------------
-	 * Design system 2.0 variables
+	 * Designsystem 2.0 variables
 	 * -----------------------------------------------------
 	 */
 
@@ -195,7 +195,7 @@
 	--color-news-accent: var(--news-accent);
 	--color-news-background: var(--news-background);
 
-	/* Neutral colors (TODO: Skal denne med?) */
+	/* Neutral colors (TODO: Skal disse med?) */
 
 	--color-neutral-content: var(--neutral-content);
 	--color-neutral-background: var(--neutral-background);

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,4 +1,10 @@
 @theme {
+	/*
+	 * -----------------------------------------------------
+	 * Design system 2.0 variables
+	 * -----------------------------------------------------
+	 */
+
 	/* Typography */
 
 	--typography-font-size: 14px;
@@ -29,35 +35,35 @@
 
 	/* Brand colors */
 
-	--brand-green-variant-05: #E4F3DD;
-	--brand-green-variant-1: #9DF1AD;
-	--brand-green-variant-2: #287938;
-	--brand-green-variant-3: #1C5B29;
-	--brand-green-variant-4: #0A4431;
-	--brand-green-variant-5: #0F3329;
+	--brand-green-05: #E4F3DD;
+	--brand-green-1: #9DF1AD;
+	--brand-green-2: #287938;
+	--brand-green-3: #1C5B29;
+	--brand-green-4: #0A4431;
+	--brand-green-5: #0F3329;
 
-	--brand-blue-variant-1: #E3ECF9;
+	--brand-blue-1: #E3ECF9;
 
-	--brand-orange-variant-1: #FBEEC8;
-	--brand-orange-variant-2: #FCD1A4;
-	--brand-orange-variant-3: #FEB37F;
-	--brand-orange-variant-4: #FF965B;
-	--brand-orange-variant-5: #A73C2E;
+	--brand-orange-1: #FBEEC8;
+	--brand-orange-2: #FCD1A4;
+	--brand-orange-3: #FEB37F;
+	--brand-orange-4: #FF965B;
+	--brand-orange-5: #A73C2E;
 
-	--brand-beige-variant-05: #FAF9F3;
-	--brand-beige-variant-1: #E5E2D7;
+	--brand-beige-05: #FAF9F3;
+	--brand-beige-1: #E5E2D7;
 
-	--brand-black-variant-1: #000000;
+	--brand-black-1: #000000;
 
-	--brand-white-variant-1: #FFFFFF;
+	--brand-white-1: #FFFFFF;
 
-	--brand-grey-variant-05: #F8F8F8;
-	--brand-grey-variant-1: #EBEBEB;
-	--brand-grey-variant-2: #D7D7D7;
-	--brand-grey-variant-3: #C2C2C2;
-	--brand-grey-variant-4: #8E8D8D;
-	--brand-grey-variant-5: #545454;
-	--brand-grey-variant-6: #1D1D1D;
+	--brand-grey-05: #F8F8F8;
+	--brand-grey-1: #EBEBEB;
+	--brand-grey-2: #D7D7D7;
+	--brand-grey-3: #C2C2C2;
+	--brand-grey-4: #8E8D8D;
+	--brand-grey-5: #545454;
+	--brand-grey-6: #1D1D1D;
 
 	/* Error colors */
 
@@ -75,7 +81,7 @@
 
 	--info-content: #133565;
 	--info-accent: #2A6AC5;
-	--info-background: var(--brand-blue-variant-1);
+	--info-background: var(--brand-blue-1);
 
 	/* News colors */
 
@@ -85,14 +91,14 @@
 
 	/* Neutral colors */
 
-	--neutral-content: var(--brand-black-variant-1);
-	--neutral-background: var(--brand-grey-variant-1);
+	--neutral-content: var(--brand-black-1);
+	--neutral-background: var(--brand-grey-1);
 
 	/* Shadows */
 
-	--custom-shadows-variant-1: 0px 4px 20px 0px rgba(0, 0, 0, 0.05);
-	--custom-shadows-variant-2: 0px 8px 20px 5px rgba(0, 0, 0, 0.05);
-	--custom-shadows-variant-3: 0px 12px 20px 10px rgba(0, 0, 0, 0.05);
+	--box-shadow-01: 0px 4px 20px 0px rgba(0, 0, 0, 0.05);
+	--box-shadow-02: 0px 8px 20px 5px rgba(0, 0, 0, 0.05);
+	--box-shadow-03: 0px 12px 20px 10px rgba(0, 0, 0, 0.05);
 
 	/* Border radius */
 
@@ -103,103 +109,105 @@
 
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind colors
+	 * Tailwind colors (TODO: Sjekke opp mot Figma)
 	 * -----------------------------------------------------
 	 */
 
-	/* Background colors */
-
-	--color-background-default: var(--brand-beige-variant-05);
-	--color-background-paper: var(--brand-white-variant-1);
-	--color-background-white: var(--brand-white-variant-1);
-	--color-background-beige: var(--brand-beige-variant-05);
-	--color-background-green: var(--brand-green-variant-05);
-	--color-background-gray: var(--brand-grey-variant-05);
-	--color-background-floating: --alpha(var(--brand-black-variant-1) / 80%);
-	--color-background-dark-green: var(--brand-green-variant-5);
-
-	/* Fills colors */
-
-	--color-fills-primary: var(--brand-green-variant-4);
-	--color-fills-secondary: var(--brand-green-variant-3);
-	--color-fills-primary-hover: var(--brand-black-variant-1);
-	--color-fills-hover: var(--brand-green-variant-05);
-
 	/* Text colors */
 
-	--color-text-primary: var(--brand-grey-variant-6);
-	--color-text-primary-invert: var(--brand-white-variant-1);
-	--color-text-secondary: var(--brand-grey-variant-5);
-	--color-text-disabled: var(--brand-grey-variant-4);
+	--color-text-primary: var(--brand-grey-6);
+	--color-text-primary-invert: var(--brand-white-1);
+	--color-text-secondary: var(--brand-grey-5);
+	--color-text-disabled: var(--brand-grey-4);
 
-	/* Primary colors */
+	/* Content link colors */
 
-	--color-primary-main: var(--brand-green-variant-4);
-	--color-primary-contrast-text: var(--brand-white-variant-1);
-	--color-primary-dark: var(--brand-black-variant-1);
-	--color-primary-background: var(--brand-green-variant-4);
+	--color-content-link: var(--brand-black-1);
 
-	/* Secondary colors */
+	/* Fill colors */
 
-	--color-secondary-main: var(--brand-green-variant-3);
-	--color-secondary-contrast-text: var(--brand-white-variant-1);
-	--color-secondary-dark: var(--brand-green-variant-4);
-	--color-secondary-background: var(--brand-green-variant-3);
+	--color-fill-primary: var(--brand-green-4);
+	--color-fill-secondary: var(--brand-green-3);
+	--color-fill-primary-hover: var(--brand-black-1);
+	--color-fill-hover: var(--brand-green-05);
+
+	/* Background colors */
+
+	--color-background-default: var(--brand-beige-05); /* TODO: Skal denne med? */
+	--color-background-paper: var(--brand-white-1); /* TODO: Skal denne med? */
+	--color-background-white: var(--brand-white-1);
+	--color-background-beige: var(--brand-beige-05);
+	--color-background-green: var(--brand-green-05);
+	--color-background-gray: var(--brand-grey-05);
+	--color-background-floating: --alpha(var(--brand-black-1) / 80%);
+	--color-background-darkgreen: var(--brand-green-5);
+
+	/* Border colors */
+
+	--color-border-default: var(--brand-grey-3);
+	--color-border-active: var(--brand-grey-6);
+	--color-border-line: var(--brand-beige-1);
+	--color-border-highlight: var(--brand-green-1);
+	--color-border-disabled: var(--brand-grey-1);
+	--color-border-invert: var(--brand-white-1);
+
+	/* Primary colors (TODO: Skal disse med?) */
+
+	--color-primary-main: var(--brand-green-4);
+	--color-primary-contrast-text: var(--brand-white-1);
+	--color-primary-dark: var(--brand-black-1);
+	--color-primary-background: var(--brand-green-4);
+
+	/* Secondary colors (TODO: Skal disse med?) */
+
+	--color-secondary-main: var(--brand-green-3);
+	--color-secondary-contrast-text: var(--brand-white-1);
+	--color-secondary-dark: var(--brand-green-4);
+	--color-secondary-background: var(--brand-green-3);
 
 	/* Success colors */
 
-	--color-success-main: var(--brand-green-variant-5);
-	--color-success-light: var(--brand-green-variant-1);
-	--color-success-accent: var(--brand-green-variant-3);
-	--color-success-background: var(--brand-green-variant-05);
+	--color-success-content: var(--brand-green-5);
+	--color-success-accent: var(--brand-green-3);
+	--color-success-background: var(--brand-green-05);
 
 	/* Error colors */
 
-	--color-error-main: var(--error-content);
+	--color-error-content: var(--error-content);
 	--color-error-accent: var(--error-accent);
 	--color-error-background: var(--error-background);
 
 	/* Warning colors */
 
-	--color-warning-main: var(--warning-content);
+	--color-warning-content: var(--warning-content);
 	--color-warning-accent: var(--warning-accent);
 	--color-warning-background: var(--warning-background);
 
 	/* Info colors */
 
-	--color-info-main: var(--info-content);
+	--color-info-content: var(--info-content);
 	--color-info-accent: var(--info-accent);
 	--color-info-background: var(--info-background);
 
 	/* News colors */
 
-	--color-news-main: var(--news-content);
+	--color-news-content: var(--news-content);
 	--color-news-accent: var(--news-accent);
 	--color-news-background: var(--news-background);
 
-	/* Neutral colors */
+	/* Neutral colors (TODO: Skal denne med?) */
 
-	--color-neutral-main: var(--neutral-content);
+	--color-neutral-content: var(--neutral-content);
 	--color-neutral-background: var(--neutral-background);
 
 	/* Disabled colors */
 
-	--color-disabled-main: var(--brand-grey-variant-5);
-	--color-disabled-content: var(--brand-grey-variant-5);
-	--color-disabled-background: var(--brand-grey-variant-1);
+	--color-disabled-content: var(--brand-grey-5);
+	--color-disabled-background: var(--brand-grey-1);
 
-	/* Border colors */
+	/* Action colors (TODO: Skal denne med?) */
 
-	--color-borders-default: var(--brand-grey-variant-3);
-	--color-borders-active: var(--brand-grey-variant-6);
-	--color-borders-line: var(--brand-beige-variant-1);
-	--color-borders-highlight: var(--brand-green-variant-1);
-	--color-borders-disabled: var(--brand-grey-variant-1);
-	--color-borders-inverted: var(--brand-white-variant-1);
-
-	/* Action colors */
-
-	--color-action-hover: var(--brand-green-variant-05);
+	--color-action-hover: var(--brand-green-05);
 
 	/*
 	 * -----------------------------------------------------

--- a/tailwind.css
+++ b/tailwind.css
@@ -89,7 +89,7 @@
 	--news-accent: #7540D6;
 	--news-background: #E6D9FF;
 
-	/* Neutral colors */
+	/* Neutral colors (TODO: Skal disse med?) */
 
 	--neutral-content: var(--brand-black-1);
 	--neutral-background: var(--brand-grey-1);

--- a/tailwind.css
+++ b/tailwind.css
@@ -59,26 +59,34 @@
 	--brand-grey-variant-5: #545454;
 	--brand-grey-variant-6: #1D1D1D;
 
-	/* Warnings colors */
+	/* Error colors */
 
-	--warnings-error-content: #631901;
-	--warnings-error-accent: #EB3B00;
-	--warnings-error-background: #FFDCD7;
+	--error-content: #631901;
+	--error-accent: #EB3B00;
+	--error-background: #FFDCD7;
 
-	--warnings-warning-content: #4D3814;
-	--warnings-warning-accent: #E25F00;
-	--warnings-warning-background: #FFEED1;
+	/* Warning colors */
 
-	--warnings-info-content: #133565;
-	--warnings-info-accent: #2A6AC5;
-	--warnings-info-background: var(--brand-blue-variant-1);
+	--warning-content: #4D3814;
+	--warning-accent: #E25F00;
+	--warning-background: #FFEED1;
 
-	--warnings-news-content: #230064;
-	--warnings-news-accent: #7540D6;
-	--warnings-news-background: #E6D9FF;
+	/* Info colors */
 
-	--warnings-neutral-content: var(--brand-black-variant-1);
-	--warnings-neutral-background: var(--brand-grey-variant-1);
+	--info-content: #133565;
+	--info-accent: #2A6AC5;
+	--info-background: var(--brand-blue-variant-1);
+
+	/* News colors */
+
+	--news-content: #230064;
+	--news-accent: #7540D6;
+	--news-background: #E6D9FF;
+
+	/* Neutral colors */
+
+	--neutral-content: var(--brand-black-variant-1);
+	--neutral-background: var(--brand-grey-variant-1);
 
 	/* Shadows */
 
@@ -147,32 +155,32 @@
 
 	/* Error colors */
 
-	--color-error-main: var(--warnings-error-content);
-	--color-error-accent: var(--warnings-error-accent);
-	--color-error-background: var(--warnings-error-background);
+	--color-error-main: var(--error-content);
+	--color-error-accent: var(--error-accent);
+	--color-error-background: var(--error-background);
 
 	/* Warning colors */
 
-	--color-warning-main: var(--warnings-warning-content);
-	--color-warning-accent: var(--warnings-warning-accent);
-	--color-warning-background: var(--warnings-warning-background);
+	--color-warning-main: var(--warning-content);
+	--color-warning-accent: var(--warning-accent);
+	--color-warning-background: var(--warning-background);
 
 	/* Info colors */
 
-	--color-info-main: var(--warnings-info-content);
-	--color-info-accent: var(--warnings-info-accent);
-	--color-info-background: var(--warnings-info-background);
+	--color-info-main: var(--info-content);
+	--color-info-accent: var(--info-accent);
+	--color-info-background: var(--info-background);
 
 	/* News colors */
 
-	--color-news-main: var(--warnings-news-content);
-	--color-news-accent: var(--warnings-news-accent);
-	--color-news-background: var(--warnings-news-background);
+	--color-news-main: var(--news-content);
+	--color-news-accent: var(--news-accent);
+	--color-news-background: var(--news-background);
 
 	/* Neutral colors */
 
-	--color-neutral-main: var(--warnings-neutral-content);
-	--color-neutral-background: var(--warnings-neutral-background);
+	--color-neutral-main: var(--neutral-content);
+	--color-neutral-background: var(--neutral-background);
 
 	/* Disabled colors */
 

--- a/tailwind.css
+++ b/tailwind.css
@@ -243,13 +243,13 @@
 
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind spacing (TODO: Finnes ikke i tailwind ... bare ha som variabler?)
+	 * Tailwind spacing (TODO: Finnes kanskje fra før i tailwind?)
 	 * -----------------------------------------------------
 	 */
 
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind border radius
+	 * Tailwind border radiuses
 	 * -----------------------------------------------------
 	 */
 

--- a/tailwind.css
+++ b/tailwind.css
@@ -195,19 +195,58 @@
 
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind font sizes
+	 * Tailwind font sizes (TODO: breakpoints?)
 	 * -----------------------------------------------------
 	 */
 
-	--text-size-12: var(--typography-font-size-12);
-	--text-size-14: var(--typography-font-size-14);
-	--text-size-16: var(--typography-font-size-16);
-	--text-size-20: var(--typography-font-size-20);
-	--text-size-24: var(--typography-font-size-24);
-	--text-size-32: var(--typography-font-size-32);
-	--text-size-40: var(--typography-font-size-40);
-	--text-size-48: var(--typography-font-size-48);
-	--text-size-56: var(--typography-font-size-56);
-	--text-size-72: var(--typography-font-size-72);
-	--text-size-96: var(--typography-font-size-96);
+	--text-2xl: var(--typography-font-size-48);
+	--text-2xl--line-height: var(--typography-line-height-150);
+
+	--text-xl: var(--typography-font-size-24);
+	--text-xl--line-height: var(--typography-line-height-150);
+
+	--text-lg: var(--typography-font-size-20);
+	--text-lg--line-height: var(--typography-line-height-150);
+
+	--text-md: var(--typography-font-size-16);
+	--text-md--line-height: var(--typography-line-height-150);
+
+	--text-sm: var(--typography-font-size-14);
+	--text-sm--line-height: var(--typography-line-height-140);
+
+	--text-xs: var(--typography-font-size-12);
+	--text-xs--line-height: var(--typography-line-height-130);
+
+	/*--text-mono-md: var(--typography-font-size-16);
+	--text-mono-md--line-height: var(--typography-line-height-150);
+
+	--text-mono-xs: var(--typography-font-size-12);
+	--text-mono-xs--line-height: var(--typography-line-height-130);*/
+
+	/*
+	 * -----------------------------------------------------
+	 * Tailwind font famlilies
+	 * -----------------------------------------------------
+	 */
+
+	--font-suisse-intl: var(--typography-font-familiy-suisse-intl);
+	--font-suisse-neue: var(--typography-font-familiy-suisse-neue);
+	--font-suisse-intl-mono: var(--typography-font-familiy-suisse-intl-mono);
+
+	/*
+	 * -----------------------------------------------------
+	 * Tailwind spacing (TODO: Finnes ikke i tailwind ... bare ha som variabler?)
+	 * -----------------------------------------------------
+	 */
+
+	/*
+	 * -----------------------------------------------------
+	 * Tailwind border radius
+	 * -----------------------------------------------------
+	 */
+
+	--radius-none: var(--border-radius-none);
+	--radius-sm: var(--border-radius-sm);
+	--radius-md: var(--border-radius-md);
+	--radius-full: var(--border-radius-full);
 }

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,0 +1,148 @@
+@theme {
+	/* Brand colors */
+
+	--brand-green-variant-05: #E4F3DD;
+	--brand-green-variant-1: #9DF1AD;
+	--brand-green-variant-2: #287938;
+	--brand-green-variant-3: #1C5B29;
+	--brand-green-variant-4: #0A4431;
+	--brand-green-variant-5: #0F3329;
+
+	--brand-blue-variant-1: #E3ECF9;
+
+	--brand-orange-variant-1: #FBEEC8;
+	--brand-orange-variant-2: #FCD1A4;
+	--brand-orange-variant-3: #FEB37F;
+	--brand-orange-variant-4: #FF965B;
+	--brand-orange-variant-5: #A73C2E;
+
+	--brand-beige-variant-05: #FAF9F3;
+	--brand-beige-variant-1: #E5E2D7;
+
+	--brand-black-variant-1: #000000;
+
+	--brand-white-variant-1: #FFFFFF;
+
+	--brand-grey-variant-05: #F8F8F8;
+	--brand-grey-variant-1: #EBEBEB;
+	--brand-grey-variant-2: #D7D7D7;
+	--brand-grey-variant-3: #C2C2C2;
+	--brand-grey-variant-4: #8E8D8D;
+	--brand-grey-variant-5: #545454;
+	--brand-grey-variant-6: #1D1D1D;
+
+	/* Warnings colors */
+
+	--warnings-error-content: #631901;
+	--warnings-error-accent: #EB3B00;
+	--warnings-error-background: #FFDCD7;
+
+	--warnings-warning-content: #4D3814;
+	--warnings-warning-accent: #E25F00;
+	--warnings-warning-background: #FFEED1;
+
+	--warnings-info-content: #133565;
+	--warnings-info-accent: #2A6AC5;
+	--warnings-info-background: var(--brand-blue-variant-1);
+
+	--warnings-news-content: #230064;
+	--warnings-news-accent: #7540D6;
+	--warnings-news-background: #E6D9FF;
+
+	--warnings-neutral-content: var(--brand-black-variant-1);
+	--warnings-neutral-background: var(--brand-grey-variant-1);
+
+	/* Background colors */
+
+	--color-background-default: var(--brand-beige-variant-05);
+	--color-background-paper: var(--brand-white-variant-1);
+	--color-background-white: var(--brand-white-variant-1);
+	--color-background-beige: var(--brand-beige-variant-05);
+	--color-background-green: var(--brand-green-variant-05);
+	--color-background-gray: var(--brand-grey-variant-05);
+	--color-background-floating: --alpha(var(--brand-black-variant-1) / 80%);
+	--color-background-dark-green: var(--brand-green-variant-5);
+
+	/* Fills colors */
+
+	--color-fills-primary: var(--brand-green-variant-4);
+	--color-fills-secondary: var(--brand-green-variant-3);
+	--color-fills-primary-hover: var(--brand-black-variant-1);
+	--color-fills-hover: var(--brand-green-variant-05);
+
+	/* Text colors */
+
+	--color-text-primary: var(--brand-grey-variant-6);
+	--color-text-primary-invert: var(--brand-white-variant-1);
+	--color-text-secondary: var(--brand-grey-variant-5);
+	--color-text-disabled: var(--brand-grey-variant-4);
+
+	/* Primary colors */
+
+	--color-primary-main: var(--brand-green-variant-4);
+	--color-primary-contrast-text: var(--brand-white-variant-1);
+	--color-primary-dark: var(--brand-black-variant-1);
+	--color-primary-background: var(--brand-green-variant-4);
+
+	/* Secondary colors */
+
+	--color-secondary-main: var(--brand-green-variant-3);
+	--color-secondary-contrast-text: var(--brand-white-variant-1);
+	--color-secondary-dark: var(--brand-green-variant-4);
+	--color-secondary-background: var(--brand-green-variant-3);
+
+	/* Success colors */
+
+	--color-success-main: var(--brand-green-variant-5);
+	--color-success-light: var(--brand-green-variant-1);
+	--color-success-accent: var(--brand-green-variant-3);
+	--color-success-background: var(--brand-green-variant-05);
+
+	/* Error colors */
+
+	--color-error-main: var(--warnings-error-content);
+	--color-error-accent: var(--warnings-error-accent);
+	--color-error-background: var(--warnings-error-background);
+
+	/* Warning colors */
+
+	--color-warning-main: var(--warnings-warning-content);
+	--color-warning-accent: var(--warnings-warning-accent);
+	--color-warning-background: var(--warnings-warning-background);
+
+	/* Info colors */
+
+	--color-info-main: var(--warnings-info-content);
+	--color-info-accent: var(--warnings-info-accent);
+	--color-info-background: var(--warnings-info-background);
+
+	/* News colors */
+
+	--color-news-main: var(--warnings-news-content);
+	--color-news-accent: var(--warnings-news-accent);
+	--color-news-background: var(--warnings-news-background);
+
+	/* Neutral colors */
+
+	--color-neutral-main: var(--warnings-neutral-content);
+	--color-neutral-background: var(--warnings-neutral-background);
+
+	/* Disabled colors */
+
+	--color-disabled-main: var(--brand-grey-variant-5);
+	--color-disabled-content: var(--brand-grey-variant-5);
+	--color-disabled-background: var(--brand-grey-variant-1);
+
+	/* Border colors */
+
+	--color-borders-default: var(--brand-grey-variant-3);
+	--color-borders-active: var(--brand-grey-variant-6);
+	--color-borders-line: var(--brand-beige-variant-1);
+	--color-borders-highlight: var(--brand-green-variant-1);
+	--color-borders-disabled: var(--brand-grey-variant-1);
+	--color-borders-inverted: var(--brand-white-variant-1);
+
+	/* Action colors */
+
+	--color-action-hover: var(--brand-green-variant-05);
+}

--- a/tailwind.css
+++ b/tailwind.css
@@ -89,11 +89,6 @@
 	--news-accent: #7540D6;
 	--news-background: #E6D9FF;
 
-	/* Neutral colors (TODO: Skal disse med?) */
-
-	--neutral-content: var(--brand-black-1);
-	--neutral-background: var(--brand-grey-1);
-
 	/* Shadows */
 
 	--box-shadow-01: 0px 4px 20px 0px rgba(0, 0, 0, 0.05);
@@ -109,7 +104,7 @@
 
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind colors (TODO: Sjekke opp mot Figma)
+	 * Tailwind colors
 	 * -----------------------------------------------------
 	 */
 
@@ -195,23 +190,14 @@
 	--color-news-accent: var(--news-accent);
 	--color-news-background: var(--news-background);
 
-	/* Neutral colors (TODO: Skal disse med?) */
-
-	--color-neutral-content: var(--neutral-content);
-	--color-neutral-background: var(--neutral-background);
-
 	/* Disabled colors */
 
 	--color-disabled-content: var(--brand-grey-5);
 	--color-disabled-background: var(--brand-grey-1);
 
-	/* Action colors (TODO: Skal denne med?) */
-
-	--color-action-hover: var(--brand-green-05);
-
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind font sizes (TODO: breakpoints?)
+	 * Tailwind font sizes (TODO: breakpoints)
 	 * -----------------------------------------------------
 	 */
 
@@ -233,12 +219,6 @@
 	--text-xs: var(--typography-font-size-12);
 	--text-xs--line-height: var(--typography-line-height-130);
 
-	/*--text-mono-md: var(--typography-font-size-16);
-	--text-mono-md--line-height: var(--typography-line-height-150);
-
-	--text-mono-xs: var(--typography-font-size-12);
-	--text-mono-xs--line-height: var(--typography-line-height-130);*/
-
 	/*
 	 * -----------------------------------------------------
 	 * Tailwind font famlilies
@@ -251,9 +231,11 @@
 
 	/*
 	 * -----------------------------------------------------
-	 * Tailwind spacing (TODO: Finnes kanskje fra før i tailwind?)
+	 * Tailwind spacing
 	 * -----------------------------------------------------
 	 */
+
+	--spacing: 1px;
 
 	/*
 	 * -----------------------------------------------------

--- a/tailwind.css
+++ b/tailwind.css
@@ -1,4 +1,29 @@
 @theme {
+	/* Typography */
+
+	--typography-font-size: 14px;
+	--typography-font-family: "'Suisse Intl', 'Suisse Intl Mono', 'Suisse Neue', Arial, sans-serif";
+	--typography-font-weight-bold: 500;
+	--typography-font-weight-roman: 400;
+	--typography-line-height-100: 1.0;
+	--typography-line-height-110: 1.1;
+	--typography-line-height-120: 1.2;
+	--typography-line-height-125: 1.25;
+	--typography-line-height-130: 1.3;
+	--typography-line-height-140: 1.4;
+	--typography-line-height-150: 1.5;
+	--typography-font-size-12: 12px;
+	--typography-font-size-14: 14px;
+	--typography-font-size-16: 16px;
+	--typography-font-size-20: 20px;
+	--typography-font-size-24: 24px;
+	--typography-font-size-32: 32px;
+	--typography-font-size-40: 40px;
+	--typography-font-size-48: 48px;
+	--typography-font-size-56: 56px;
+	--typography-font-size-72: 72px;
+	--typography-font-size-96: 96px;
+
 	/* Brand colors */
 
 	--brand-green-variant-05: #E4F3DD;
@@ -51,6 +76,25 @@
 
 	--warnings-neutral-content: var(--brand-black-variant-1);
 	--warnings-neutral-background: var(--brand-grey-variant-1);
+
+	/* Shadows */
+
+	--custom-shadows-variant-1: 0px 4px 20px 0px rgba(0, 0, 0, 0.05);
+	--custom-shadows-variant-2: 0px 8px 20px 5px rgba(0, 0, 0, 0.05);
+	--custom-shadows-variant-3: 0px 12px 20px 10px rgba(0, 0, 0, 0.05);
+
+	/* Border radius */
+
+	--border-radius-none: 0px;
+	--border-radius-sm: 2px;
+	--border-radius-md: 4px;
+	--border-radius-full: 9999px;
+
+	/*
+	 * -----------------------------------------------------
+	 * Tailwind colors
+	 * -----------------------------------------------------
+	 */
 
 	/* Background colors */
 
@@ -145,4 +189,22 @@
 	/* Action colors */
 
 	--color-action-hover: var(--brand-green-variant-05);
+
+	/*
+	 * -----------------------------------------------------
+	 * Tailwind font sizes
+	 * -----------------------------------------------------
+	 */
+
+	--text-size-12: var(--typography-font-size-12);
+	--text-size-14: var(--typography-font-size-14);
+	--text-size-16: var(--typography-font-size-16);
+	--text-size-20: var(--typography-font-size-20);
+	--text-size-24: var(--typography-font-size-24);
+	--text-size-32: var(--typography-font-size-32);
+	--text-size-40: var(--typography-font-size-40);
+	--text-size-48: var(--typography-font-size-48);
+	--text-size-56: var(--typography-font-size-56);
+	--text-size-72: var(--typography-font-size-72);
+	--text-size-96: var(--typography-font-size-96);
 }


### PR DESCRIPTION
Allows projects that use Tailwind in addition to MUI to use the theme styles with tailwind classes without having to redefine them in the project.

In `global.css` in the project:

```
@import "tailwindcss";
@import "../../node_modules/@digitalarkivet/mui-theme/tailwind.css";
```

Colors can be used by their color token name:

```
<div className="bg-background-green p-8"></div>
```

Or by using the color variable names:

```
<div className="bg-[var(--brand-green-05)] p-8"></div>
```