### PR TITLE
Disable package manager cache

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version-file: .node-version
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - run: pnpm run ci
       - run: pnpm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           package_json_file: package.json
 
@@ -28,4 +28,4 @@ jobs:
 
       - run: pnpm run ci
       - run: pnpm run build
-      - run: npm publish --no-git-checks --provenance --access public
+      - run: pnpm publish --no-git-checks --access public


### PR DESCRIPTION
Also revert to using pnpm publish, [provenance should be default true](https://docs.npmjs.com/trusted-publishers#automatic-provenance-generation).