### PR TITLE
Add ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,28 @@
   "description": "MUI themes for Digitalarkivet applications",
   "private": false,
   "author": "Nasjonalarkivet",
+  "main": "./dist/main.js",
+  "module": "./dist/esm/main.js",
+  "types": "./dist/main.d.ts",
   "exports": {
-    ".": "./dist/main.js",
-    "./components/*": "./dist/components/*.js"
+    ".": {
+      "types": "./dist/main.d.ts",
+      "import": "./dist/esm/main.js",
+      "require": "./dist/main.js",
+      "default": "./dist/esm/main.js"
+    },
+    "./light": {
+      "types": "./dist/light.d.ts",
+      "import": "./dist/esm/light.js",
+      "require": "./dist/light.js",
+      "default": "./dist/esm/light.js"
+    },
+    "./components/*": {
+      "types": "./dist/components/*.d.ts",
+      "import": "./dist/esm/components/*.js",
+      "require": "./dist/components/*.js",
+      "default": "./dist/esm/components/*.js"
+    }
   },
   "license": "MIT",
   "homepage": "https://digitalarkivet.no",
@@ -22,7 +41,7 @@
     "url": "https://github.com/nasjonalarkivet/da-mui-theme/issues"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.dist.json",
+    "build": "tsc -p tsconfig.dist.json && tsc -p tsconfig.esm.json && node scripts/write-esm-package-json.mjs",
     "prepare": "pnpm build",
     "gallery": "pnpm webpack serve",
     "clean": "rm -r dist/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalarkivet/mui-theme",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "MUI themes for Digitalarkivet applications",
   "private": false,
   "author": "Nasjonalarkivet",

--- a/scripts/write-esm-package-json.mjs
+++ b/scripts/write-esm-package-json.mjs
@@ -1,0 +1,39 @@
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs"
+import { extname, join } from "node:path"
+
+mkdirSync("dist/esm", { recursive: true })
+writeFileSync("dist/esm/package.json", `${JSON.stringify({ type: "module" }, null, 2)}\n`)
+
+const addJsExtension = specifier => {
+	if (!specifier.startsWith(".") || extname(specifier)) {
+		return specifier
+	}
+	return `${specifier}.js`
+}
+
+const rewriteRelativeImports = filePath => {
+	const source = readFileSync(filePath, "utf8")
+	const rewritten = source.replace(
+		/\b(from\s*["']|import\s*["'])(\.{1,2}\/[^"']+)(["'])/g,
+		(_, prefix, specifier, suffix) => `${prefix}${addJsExtension(specifier)}${suffix}`,
+	)
+
+	if (rewritten !== source) {
+		writeFileSync(filePath, rewritten)
+	}
+}
+
+const walk = directory => {
+	for (const entry of readdirSync(directory)) {
+		const entryPath = join(directory, entry)
+		if (statSync(entryPath).isDirectory()) {
+			walk(entryPath)
+			continue
+		}
+		if (entryPath.endsWith(".js")) {
+			rewriteRelativeImports(entryPath)
+		}
+	}
+}
+
+walk("dist/esm")

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import "./types/theme"
-import theme from "./light"
+import "./types/theme.js"
+import theme from "./light.js"
 
 export default theme

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.dist.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist/esm",
+    "declaration": false,
+    "declarationMap": false
+  }
+}


### PR DESCRIPTION
Gjør at `@digitalarkivet/mui-theme` bygges og publiseres både som CommonJS og ESM.

Betyr at eksisterende brukere som laster ned pakken via `require` fortsatt får dagens CommonJS-build fra `dist/`, mens moderne bundlere som Next/Turbopack kan velge ESM-builden fra `dist/esm/` automatisk via `package.json` exports. Dette skal gi bedre tree-shaking, særlig for imports som `@mui/material/locale`, der CommonJS-builden kan dra inn mer kode enn nødvendig.

Lagt til et postbuild-steg for å gjøre ESM-outputen gyldig med `.js` på relative imports og "type": "module" i dist/esm, fordi mottak-web krasjet på ESM-entrypointen uten dette.

Ved verifisering i mottak-web ble resultatet (sammenlignet med tidligere):
```
develop:
.next/static: 3.8M
gzip JS/CSS: 825,121
største chunk: 208K

før da-mui-theme-fiks:
.next/static: 47M
gzip JS/CSS: 7,132,520
største chunks: 6 x 7.5M

etter 4.1.1:
.next/static: 5.3M
gzip JS/CSS: 1,485,233
største chunks: 6 x 560K

etter ESM-build:
.next/static: 2.6M
gzip JS/CSS: 845,356
største chunk: 208K
```